### PR TITLE
Add missing "superagent"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "rss": "^1.1.1",
     "socket.io": "^1.0.6",
     "static-favicon": "^2.0.0-alpha",
+    "superagent": "^1.2.0",
     "underscore": "^1.6.0",
     "xml2js": "^0.4.4"
   }


### PR DESCRIPTION
依存関係からsuperagentが抜けているため、gruntでビルドするときにエラーが起きてるのを修正しました。

```sh
$ npm prune
$ grunt
Running "browserify:build" (browserify) task
>> Error: Cannot find module 'superagent' from '/Users/azu/.ghq/github.com/ytanaka-/menthas/assets/actions'
Warning: Error running grunt-browserify. Use --force to continue.

Aborted due to warnings.
```

使ってる箇所: https://github.com/ytanaka-/menthas/blob/0aaf75a014d7228f3dc3c8806fe93705fbab407f/assets/actions/actions.coffee#L1